### PR TITLE
CF-783: use flag > cfg for region value

### DIFF
--- a/cmd/command/handler/validate.go
+++ b/cmd/command/handler/validate.go
@@ -26,13 +26,10 @@ var ValidateCommand = cli.Command{
 	},
 	Action: func(c *cli.Context) error {
 		id := c.String("id")
+		awsRegion := c.String("aws-region")
 
 		if c.String("runtime") != "aws-lambda" {
 			return errors.New("unsupported runtime. Supported runtimes are [aws-lambda]")
-		}
-		awsRegion := c.String("aws-region")
-		if awsRegion == "" {
-			return errors.New("aws-region must be specified")
 		}
 
 		providerRuntime, err := handlerclient.NewLambdaRuntime(c.Context, id)

--- a/cmd/command/handler/validate.go
+++ b/cmd/command/handler/validate.go
@@ -26,16 +26,23 @@ var ValidateCommand = cli.Command{
 	},
 	Action: func(c *cli.Context) error {
 		id := c.String("id")
-		awsRegion := c.String("aws-region")
+
 		if c.String("runtime") != "aws-lambda" {
 			return errors.New("unsupported runtime. Supported runtimes are [aws-lambda]")
 		}
+		awsRegion := c.String("aws-region")
+		if awsRegion == "" {
+			return errors.New("aws-region must be specified")
+		}
+
 		providerRuntime, err := handlerclient.NewLambdaRuntime(c.Context, id)
 		if err != nil {
 			return err
 		}
 		// check the cloudformation stack here.
 		cfg, err := cfaws.ConfigFromContextOrDefault(c.Context)
+		// ensure cli flag region is used
+		cfg.Region = awsRegion
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION

https://linear.app/common-fate/issue/CF-783/cf-handler-validate-does-not-seem-to-respect-aws-region-flag