### PR TITLE
hotfix: cf login to preserve config

### DIFF
--- a/cmd/command/login.go
+++ b/cmd/command/login.go
@@ -108,9 +108,15 @@ func (lf LoginFlow) LoginAction(c *cli.Context) error {
 
 		// update the config file
 		cfg.CurrentContext = "default"
-		cfg.Contexts["default"] = config.Context{
-			DashboardURL: res.DashboardURL,
+
+		// is it a new URL if so, add it and reset config
+		// otherwise it stays the same (which will preserve existing config; api_url)
+		if cfg.Contexts["default"].DashboardURL != res.DashboardURL {
+			cfg.Contexts["default"] = config.Context{
+				DashboardURL: res.DashboardURL,
+			}
 		}
+
 		err = config.Save(cfg)
 		if err != nil {
 			return err


### PR DESCRIPTION
Micro PR here that meets the following DE

**DE**

For the following config file
```
current_context = "default"

[context]
  [context.default]
    dashboard_url = "http://localhost:3000"
    api_url = "http://localhost:8080"
  [context.prod]
    dashboard_url = "https://internal.prod.granted.run"
```

`cf login` (on its own) will not override the `context.default`, preserving api_url whilst still refreshing the credentials  ✅ 

`cf login https://internal.prod.granted.run` will override the `context.default` 

Note: I couldn't find much in the way of existing spec for this feature, desired behaviour. I think this is a solid hotfix that makes dev less unexpected 