### PR TITLE
Fix refresh token process not working

### DIFF
--- a/pkg/tokenstore/notify_token_store.go
+++ b/pkg/tokenstore/notify_token_store.go
@@ -31,10 +31,10 @@ func (s *NotifyRefreshTokenSource) Token() (*oauth2.Token, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.T.Valid() {
-		zap.S().Debug("returning cached oauth2 in-memory token")
+		zap.S().Debugw("returning cached oauth2 in-memory token", "expiry", s.T.Expiry)
 		return s.T, nil
 	}
-	zap.S().Debug("refreshing oauth2 token")
+	zap.S().Debug("refreshing oauth2 token", "expiry", s.T.Expiry)
 	t, err := s.New.Token()
 	if err != nil {
 		return nil, err

--- a/pkg/tokenstore/notify_token_store.go
+++ b/pkg/tokenstore/notify_token_store.go
@@ -30,10 +30,11 @@ func StoreNewToken(t *oauth2.Token) error {
 func (s *NotifyRefreshTokenSource) Token() (*oauth2.Token, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.T.Valid() {
-		zap.S().Debug("returning cached in-memory token")
-		return s.T, nil
-	}
+	// if s.T.Valid() {
+	// 	zap.S().Debug("returning cached in-memory token")
+	// 	return s.T, nil
+	// }
+	zap.S().Debug("refreshing token")
 	t, err := s.New.Token()
 	if err != nil {
 		return nil, err

--- a/pkg/tokenstore/notify_token_store.go
+++ b/pkg/tokenstore/notify_token_store.go
@@ -30,11 +30,11 @@ func StoreNewToken(t *oauth2.Token) error {
 func (s *NotifyRefreshTokenSource) Token() (*oauth2.Token, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	// if s.T.Valid() {
-	// 	zap.S().Debug("returning cached in-memory token")
-	// 	return s.T, nil
-	// }
-	zap.S().Debug("refreshing token")
+	if s.T.Valid() {
+		zap.S().Debug("returning cached oauth2 in-memory token")
+		return s.T, nil
+	}
+	zap.S().Debug("refreshing oauth2 token")
 	t, err := s.New.Token()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
After the initial access token expires, the token refresh process didn't work. This PR fixes that. The root cause of the issue is that the Cognito API Gateway integration for Common Fate OSS uses an ID token, rather than an access token. When the token is refreshed, we didn't replace the returned access token with the ID token.