### PR TITLE
Jack/cf 1731 ability to check token expiration and prompt user for re

### DIFF
--- a/cmd/command/login.go
+++ b/cmd/command/login.go
@@ -67,14 +67,16 @@ func (lf LoginFlow) LoginAction(c *cli.Context) error {
 	}
 
 	//what do we consider to be 'close to expiry' for now ill set it at 5 minutes?
-	now := time.Now()
-	timeDifference := (time.Minute * 5)
-	//maybe we add a flag here to gate this as well
-	if token.Expiry.Unix()-now.Unix() > int64(timeDifference) {
-		//not within the range where we want to re-login
-		clio.Infow("Auth token still valid, skipping login flow.")
+	if token != nil {
+		now := time.Now()
+		timeDifference := (time.Minute * 5)
+		//maybe we add a flag here to gate this as well
+		if token.Expiry.Unix()-now.Unix() > int64(timeDifference) {
+			//not within the range where we want to re-login
+			clio.Infow("Auth token still valid, skipping login flow.")
 
-		return nil
+			return nil
+		}
 	}
 
 	authResponse := make(chan authflow.Response)

--- a/cmd/command/login.go
+++ b/cmd/command/login.go
@@ -19,7 +19,7 @@ var Login = cli.Command{
 	Name:  "login",
 	Usage: "Log in to Common Fate",
 	Flags: []cli.Flag{
-		&cli.BoolFlag{Name: "lazy", Usage: "the lazy flag lets granted decide whether a new login flow should be initiated based on the token expiry"},
+		&cli.BoolFlag{Name: "lazy", Usage: "the lazy flag lets granted decide whether a new login flow should be initiated based on the token expiry", Aliases: []string{"l"}},
 	},
 	Action: defaultLoginFlow.LoginAction,
 }

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/common-fate/apikit v0.2.1-0.20220526131641-1d860b34f6ed // indirect
 	github.com/common-fate/iso8601 v1.0.2 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.11.0 // indirect
 	github.com/dvsekhvalnov/jose2go v1.5.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
@@ -73,8 +74,10 @@ require (
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/nathan-fiscaletti/consolesize-go v0.0.0-20220204101620-317176b6684d // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/segmentio/ksuid v1.0.4 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 // indirect

--- a/go.sum
+++ b/go.sum
@@ -438,6 +438,9 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
@@ -465,6 +468,7 @@ go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
+go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.8.0 h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
 go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -68,9 +68,10 @@ func (rd *ErrorHandlingClient) Do(req *http.Request) (*http.Response, error) {
 
 	if res.StatusCode == http.StatusUnauthorized {
 		if cfContext.DashboardURL != "" {
-			return nil, clierr.New(fmt.Sprintf("To log in to Common Fate, run: run: '%s %s'", rd.LoginHint, cfContext.DashboardURL))
+			e.Messages = append(e.Messages, clierr.Infof("To log in to Common Fate, run: run: '%s %s'", rd.LoginHint, cfContext.DashboardURL))
+		} else {
+			e.Messages = append(e.Messages, clierr.Infof("To log in to Common Fate, run: '%s'", rd.LoginHint))
 		}
-		e.Messages = append(e.Messages, clierr.Infof("To log in to Common Fate, run: '%s'", rd.LoginHint))
 	}
 
 	return res, e

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -67,6 +67,9 @@ func (rd *ErrorHandlingClient) Do(req *http.Request) (*http.Response, error) {
 	e := clierr.New(fmt.Sprintf("Common Fate API returned an error (code %v): %s", res.StatusCode, string(body)))
 
 	if res.StatusCode == http.StatusUnauthorized {
+		if cfContext.DashboardURL != "" {
+			return nil, clierr.New(fmt.Sprintf("To log in to Common Fate, run: run: '%s %s'", rd.LoginHint, cfContext.DashboardURL))
+		}
 		e.Messages = append(e.Messages, clierr.Infof("To log in to Common Fate, run: '%s'", rd.LoginHint))
 	}
 

--- a/pkg/tokenstore/util.go
+++ b/pkg/tokenstore/util.go
@@ -1,0 +1,17 @@
+package tokenstore
+
+import (
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+func ShouldRefreshToken(token oauth2.Token, now time.Time) bool {
+	expiry := token.Expiry
+
+	// if the token expires up to 5 minutes in the future,
+	// refresh it now.
+	timeToRefresh := time.Now().Add(5 * time.Minute)
+
+	return expiry.Before(timeToRefresh)
+}

--- a/pkg/tokenstore/util_test.go
+++ b/pkg/tokenstore/util_test.go
@@ -38,6 +38,13 @@ func TestShouldRefresh(t *testing.T) {
 			},
 			shouldRefresh: true,
 		},
+		{
+			name: "5 minutes after refreshes",
+			token: oauth2.Token{
+				Expiry: time.Now().Add(time.Minute * -5),
+			},
+			shouldRefresh: true,
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/tokenstore/util_test.go
+++ b/pkg/tokenstore/util_test.go
@@ -1,0 +1,55 @@
+package tokenstore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"golang.org/x/oauth2"
+)
+
+func TestShouldRefresh(t *testing.T) {
+	type testcase struct {
+		name          string
+		token         oauth2.Token
+		shouldRefresh bool
+	}
+
+	testcases := []testcase{
+		{
+			name: "24 hours away passes",
+			token: oauth2.Token{
+				Expiry: time.Now().Add(time.Hour * 24),
+			},
+			shouldRefresh: false,
+		},
+		{
+			name: "2 minutes away refreshes",
+			token: oauth2.Token{
+				Expiry: time.Now().Add(time.Minute * 2),
+			},
+			shouldRefresh: true,
+		},
+		{
+			name: "5 minutes away refreshes",
+			token: oauth2.Token{
+				Expiry: time.Now().Add(time.Minute * 5),
+			},
+			shouldRefresh: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			now := time.Now()
+
+			outcome := ShouldRefreshToken(tc.token, now)
+
+			assert.Equal(t, outcome, tc.shouldRefresh)
+
+		})
+	}
+
+}


### PR DESCRIPTION
Checks expiry date of token and if `--lazy` flag is passed, will not initiate login flow if expiring is not within 5 minutes